### PR TITLE
Configure Google Sign-In client ID

### DIFF
--- a/CoodYou/CoodYou/CoodYouApp.swift
+++ b/CoodYou/CoodYou/CoodYouApp.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import FirebaseCore
+#if canImport(GoogleSignIn)
+import GoogleSignIn
+#endif
 
 @main
 struct CoodYouApp: App {
@@ -21,6 +24,11 @@ struct CoodYouApp: App {
 final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+#if canImport(GoogleSignIn)
+        if let clientID = FirebaseApp.app()?.options.clientID {
+            GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
+        }
+#endif
         true
     }
 }


### PR DESCRIPTION
## Summary
- configure the Google Sign-In shared instance with the Firebase client ID during app launch
- conditionally import GoogleSignIn when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d891dd82008326b9e0b927efefad3a