### PR TITLE
Stabilize school selection search flow

### DIFF
--- a/CoodYou/CoodYou/ViewModels/HomeViewModel.swift
+++ b/CoodYou/CoodYou/ViewModels/HomeViewModel.swift
@@ -344,9 +344,14 @@ final class HomeViewModel: ObservableObject {
         schoolResults = []
         selectedHall = nil
         isSearching = false
+
         ignoreSearchChanges = true
+        searchTask?.cancel()
         searchText = ""
-        ignoreSearchChanges = false
+
+        DispatchQueue.main.async { [weak self] in
+            self?.ignoreSearchChanges = false
+        }
     }
 
     func selectHall(_ hall: DiningHall) {

--- a/CoodYou/CoodYou/Views/HomeView.swift
+++ b/CoodYou/CoodYou/Views/HomeView.swift
@@ -186,7 +186,6 @@ struct HomeView: View {
                                 ForEach(viewModel.schoolResults) { school in
                                     Button {
                                         viewModel.activateSchool(school)
-                                        Task { await viewModel.clearSearch(preserveFilter: true) }
                                     } label: {
                                         schoolRowResult(school: school)
                                     }


### PR DESCRIPTION
## Summary
- keep the home search filter active after choosing a school by cancelling pending queries and deferring the ignore flag reset
- simplify the school result tap handling so the view model manages clearing the query without wiping the dining hall list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d92fff8eb48326bd4d459b4a13290b